### PR TITLE
DEV-6013 Unpin gem dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,8 +22,20 @@ jobs:
             chmod +x ./cc-test-reporter
 
       - run:
+          name: Update RubyGems
+          command: sudo gem update --system 3.3.25
+
+      - run:
+          name: Install bundler
+          command: gem install bundler
+
+      - run:
+          name: Configure bundler
+          command: bundle config set --local path 'vendor/bundle'
+
+      - run:
           name: Bundle Install
-          command: bundle check --path=vendor/bundle || bundle install --path=vendor/bundle --jobs=4 --retry=3
+          command: bundle check || bundle install --jobs=4 --retry=3
 
       - save_cache:
           key: ruby-cache-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile" }}-{{ checksum "ruby-parameter-store.gemspec" }}
@@ -49,6 +61,6 @@ jobs:
           command: |
             if [ "${CIRCLE_BRANCH}" == "master" ]; then
               gem build ruby-parameter-store.gemspec
-              curl --fail -F package=@ruby-parameter-store-0.0.2.gem https://NGHqu-QvDZ17MPOhTlVlKEDZi3QMZaOA4@push.fury.io/promoboxx/
+              curl --fail -F package=@ruby-parameter-store-0.0.4.gem https://NGHqu-QvDZ17MPOhTlVlKEDZi3QMZaOA4@push.fury.io/promoboxx/
             fi
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,26 +1,27 @@
 PATH
   remote: .
   specs:
-    ruby-parameter-store (0.0.1)
+    ruby-parameter-store (0.0.4)
       aws-sdk-ssm (~> 1)
 
 GEM
   remote: http://rubygems.org/
   specs:
-    aws-eventstream (1.0.1)
-    aws-partitions (1.134.0)
-    aws-sdk-core (3.46.0)
-      aws-eventstream (~> 1.0)
-      aws-partitions (~> 1.0)
-      aws-sigv4 (~> 1.0)
-      jmespath (~> 1.0)
-    aws-sdk-ssm (1.35.0)
-      aws-sdk-core (~> 3, >= 3.39.0)
-      aws-sigv4 (~> 1.0)
-    aws-sigv4 (1.0.3)
+    aws-eventstream (1.2.0)
+    aws-partitions (1.662.0)
+    aws-sdk-core (3.167.0)
+      aws-eventstream (~> 1, >= 1.0.2)
+      aws-partitions (~> 1, >= 1.651.0)
+      aws-sigv4 (~> 1.5)
+      jmespath (~> 1, >= 1.6.1)
+    aws-sdk-ssm (1.145.0)
+      aws-sdk-core (~> 3, >= 3.165.0)
+      aws-sigv4 (~> 1.1)
+    aws-sigv4 (1.5.2)
+      aws-eventstream (~> 1, >= 1.0.2)
     diff-lcs (1.3)
     docile (1.3.1)
-    jmespath (1.4.0)
+    jmespath (1.6.1)
     json (2.1.0)
     rake (12.3.2)
     rspec (3.8.0)
@@ -48,11 +49,11 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  rake (~> 12)
-  rspec (~> 3)
-  rspec_junit_formatter (~> 0.4)
+  rake (>= 12.3)
+  rspec (>= 3.8)
+  rspec_junit_formatter (>= 0.4.1)
   ruby-parameter-store!
-  simplecov (~> 0.16)
+  simplecov (>= 0.16.1)
 
 BUNDLED WITH
-   1.17.3
+   2.3.23

--- a/README.md
+++ b/README.md
@@ -4,7 +4,30 @@
 [![Maintainability](https://api.codeclimate.com/v1/badges/dbae4922f2e021549af9/maintainability)](https://codeclimate.com/repos/5c1ac8712cae6002b40016f8/maintainability)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/dbae4922f2e021549af9/test_coverage)](https://codeclimate.com/repos/5c1ac8712cae6002b40016f8/test_coverage)
 
+## Development and Building
+
+1. Update code
+2. Increment version in gemspec
+3. Increment version in Gemfury publish command in .circleci/config.yml
+4. Open pull request
+5. Merge pull request
+6. Circleci master build will publish to Gemfury
+
 ## Usage
+
+Gemfile:
+
+```ruby
+source 'https://gem.fury.io/promoboxx/' do
+  gem 'ruby-parameter-store'
+end
+```
+
+or
+
+```ruby
+gem 'ruby-jwt-auth', git: 'https://github.com/Promoboxx/ruby-parameter-store.git'
+```
 
 ### Configure the RubyParameterStore singleton in config/initializers/ruby_parameter_store.rb
 ```

--- a/ruby-parameter-store.gemspec
+++ b/ruby-parameter-store.gemspec
@@ -1,17 +1,18 @@
 Gem::Specification.new do |s|
   s.name = "ruby-parameter-store"
-  s.version = "0.0.2"
-  s.date = "2018-12-14"
+  s.version = "0.0.4"
+  s.date = "2022-11-16"
   s.author = 'Promoboxx Inc'
   s.summary = "Ruby Parameter Store implements Promoboxx parameter retrieval and coalescence in Ruby"
   s.homepage = "https://github.com/promoboxx/ruby-parameter-store"
   s.required_ruby_version = '>= 2.3.1'
 
   s.add_dependency 'aws-sdk-ssm', '~> 1'
-  s.add_development_dependency 'rake', '~> 12'
-  s.add_development_dependency 'rspec', '~> 3'
-  s.add_development_dependency 'rspec_junit_formatter', '~> 0.4'
-  s.add_development_dependency "simplecov", '~> 0.16'
+  s.add_development_dependency 'rake', '>= 12.3'
+  s.add_development_dependency 'rspec', '>= 3.8'
+  s.add_development_dependency 'rspec_junit_formatter', '>= 0.4.1'
+  s.add_development_dependency 'simplecov', '>= 0.16.1'
+
 
   s.files = [
     'lib/ruby_parameter_store.rb',


### PR DESCRIPTION
Gemspec pinned some required gem dependencies to some minor versions. PBXX2 has used later version, so these no longer work. I don't seem any reason these should not allow higher major versions, so change it.

Also looks like the Gemfile.lock wasn't saved previously. I updated the bundler version. Also added documentation on how to build a new gem version.

Jumping from 0.0.2 to 0.0.4 because Gemfury has a version 0.0.3 already.